### PR TITLE
Organise fetch requests within repository

### DIFF
--- a/frontend-web/tasks-app/src/data/TasksRepository.ts
+++ b/frontend-web/tasks-app/src/data/TasksRepository.ts
@@ -1,0 +1,76 @@
+import { Task } from "../pages/TasksPage";
+
+export class TasksRepository {
+
+
+    /**
+     * Fetch all tasks
+     * 
+     * @returns Tasks available or null if the request fails
+     */
+    async fetchAllTasks(): Promise<Task[] | null> {
+
+        // sort by done (true last) last and sort by creation date (new first)
+        // https://github.com/typicode/json-server#sort
+        const sortAndOrderSettings = "?_sort=done,created_at&_order=asc,desc"
+
+        const response = await fetch("http://localhost:3000/tasks" + sortAndOrderSettings)
+
+        if (response.ok) return await response.json() as Task[]
+        else return null
+    }
+
+    /**
+     * Send task to API to persist it
+     * 
+     * @param task task to save
+     * @returns the task id or null if the request fails
+     */
+    async saveNewTask(task: Task): Promise<string | null> {
+        const init = {
+            method: "POST",
+            body: JSON.stringify(task),
+            headers: {
+                "Content-Type": "application/json",
+            },
+        };
+
+        const response = await fetch("http://localhost:3000/tasks", init)
+
+        if (response.ok) return task.id;
+        else return null
+    }
+
+    /**
+     * 
+     * @param task task to save
+     * @returns the task id or null if the request fails
+     */
+    async updateTask(task: Task): Promise<string | null> {
+        const init = {
+            method: "PUT",
+            body: JSON.stringify(task),
+            headers: {
+                "Content-Type": "application/json",
+            },
+        };
+
+        const response = await fetch(`http://localhost:3000/tasks/${task.id}`, init)
+
+        if (response.ok) return task.id;
+        else return null
+    }
+
+    /**
+     * Delete stack with id from persistency
+     * 
+     * @param id task id to delete
+     * @returns true if the task was deleted successfully
+     */
+    async deleteTask(id: string): Promise<boolean> {
+        const response = await fetch(`http://localhost:3000/tasks/${id}`, { method: "DELETE" })
+
+        if (response.ok) return true;
+        else return false
+    }
+}


### PR DESCRIPTION
### [Repositório](https://github.com/rogeriosilva-ifpi/ifpi-ads-2023.2-internet2/commit/50fdb5d1f7daae0c27459a548f76e6da398a1089)

O repositório servirá para buscar e enviar dados relevantes às tarefas, isto é, se comunicar com a API/FakeAPI, banco de dados locais, etc. Os métodos estão agora compostos dentro de uma classe com esta **única responsabilidade** e caso qualquer outro componente necessite desse acesso a dados, ja sabe _a quem pedir_.

### [UI Otimista](https://github.com/rogeriosilva-ifpi/ifpi-ads-2023.2-internet2/commit/0527fc203556f84a1856e457920931f812692dd0)

Buscando fornecer uma experiência satisfatória para o usuário utilizamos de uma técnica de prever e adiantar o efeito de sucesso de uma operação como, por exemplo, ao adicionar um item na lista. Para isso nós solicitamos que o repositório salve o item no banco de dados externo (backend) para então atualizar a lista com o novo item. Porém essa operação pode ser demorada o que custará do usuário uma experência fluída. Para mitigar este efeito, ao solicitar ao repositório para salvar o item apenas declararemos uma função de callback para quando a requisição finalizar e, enquanto o repositório age e espera, adicionamos manualmente o item na lista. Demonstrando a diferença do que o usuário percebe:

- UI preguiçosa

  1. Usuário clica em "Adicionar item"
  2. Espera de 0.5-1.5s
  3. Página recarrega com a lista atualizada


- UI otimista

  1. Usuário clica em "Adicionar item"
  2. ~~Espera de 0.5-1.5s~~
  3. ~~Página recarrega~~ Visualiza a lista atualizada
  
  > Para mais detalhes veja: [UI Otimista: o segredo para o crescimento da receita online
](https://brasil.uxdesign.cc/ui-otimista-o-segredo-para-o-crescimento-da-receita-online-a9ad9a0b9e70)